### PR TITLE
Add validation for parameters on ImageClipper constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ function imageClipper(source, options, callback) {
       callback = options
       options = null
 
+      if (utils.type(callback) !== 'Function') {
+        throw new Error('Invalid argument: Second parameter should be a function')
+      }
+
       clipper = new Clipper()
 
       clipper.image(source, function() {
@@ -41,7 +45,11 @@ function imageClipper(source, options, callback) {
     // imageClipper('path/to/image.jpg', {...}, callback)
     default:
       if (utils.type(options) !== 'Object') {
-        throw new Error('invalid arguments')
+        throw new Error('Invalid argument: options should be an object')
+      }
+
+      if (utils.type(callback) !== 'Function') {
+        throw new Error('Invalid argument: callback should be a function')
       }
 
       clipper = new Clipper(options)

--- a/test/browser/tests.js
+++ b/test/browser/tests.js
@@ -10,6 +10,8 @@ var y = 20
 var width = 100
 var height = 100
 
+var noop = function () {}
+
 function createDOM(dataUrl) {
   var img = new Image()
   img.src = dataUrl
@@ -91,6 +93,33 @@ describe('entrance method clipper()', function() {
       done()
     }
   })
+
+  it('clipper("path/to/image.jpg", { ... }) throws since callback did not be provided', function(done) {
+    try {
+      Clipper(pngImagePath, { quality: 50 });
+    } catch (e) {
+      e.message.should.equal('Invalid argument: Second parameter should be a function');
+      done();
+    }
+  });
+
+  it('clipper("path/to/image.jpg", { ... }, { ... }) throws since callback did not be provided', function(done) {
+    try {
+      Clipper(pngImagePath, { quality: 50 }, {});
+    } catch (e) {
+      e.message.should.equal('Invalid argument: callback should be a function');
+      done();
+    }
+  });
+
+  it('clipper("path/to/image.jpg", function() { ... } , function() { ... }) throws since options is not an object', function(done) {
+    try {
+      Clipper(pngImagePath, noop, noop);
+    } catch (e) {
+      e.message.should.equal('Invalid argument: options should be an object');
+      done();
+    }
+  });
 
 })
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -14,6 +14,7 @@ var y = 20
 var width = 100
 var height = 100
 
+var noop = function () {}
 // return console.log(123, Canvas)
 
 Clipper.configure({
@@ -113,6 +114,42 @@ describe('entrance method clipper()', function() {
       Clipper(pngImagePath)
     } catch (e) {
       e.message.should.equal('callback must be specified when load from path')
+      done()
+    }
+  })
+
+  it('clipper("path/to/image.jpg", { ... }) throws since callback did not be provided', function(done) {
+    try {
+      Clipper(pngImagePath, { quality: 50 })
+    } catch (e) {
+      e.message.should.equal('Invalid argument: Second parameter should be a function')
+      done()
+    }
+  })
+
+  it('clipper("path/to/image.jpg", { ... }) throws since callback was not provided', function(done) {
+    try {
+      Clipper(pngImagePath, { quality: 50 })
+    } catch (e) {
+      e.message.should.equal('Invalid argument: Second parameter should be a function')
+      done()
+    }
+  })
+
+  it('clipper("path/to/image.jpg", { ... }, { ... }) throws since callback is not a function', function(done) {
+    try {
+      Clipper(pngImagePath, { quality: 50 }, {})
+    } catch (e) {
+      e.message.should.equal('Invalid argument: callback should be a function')
+      done()
+    }
+  })
+
+  it('clipper("path/to/image.jpg", function() { ... } , function() { ... }) throws since options is not an object', function(done) {
+    try {
+      Clipper(pngImagePath, noop, noop)
+    } catch (e) {
+      e.message.should.equal('Invalid argument: options should be an object')
       done()
     }
   })


### PR DESCRIPTION
Adding validation on parameters of imageClipper's constructor to handle:
-When 2 parameters are sent validate if the second is a function (callback)
-When 3 parameters are sent validate if the second is an object (options) and if the third is a function (callback)